### PR TITLE
Display continuous star values for aggregate business ratings

### DIFF
--- a/src/main/webapp/assets/css/product-page.css
+++ b/src/main/webapp/assets/css/product-page.css
@@ -99,12 +99,10 @@
 }
 
 .star:after {
-  font-family: Font Awesome 5 Free;
   content: "\f005";
   position: absolute;
-  left: 0;
+  left: 0;  
   top: 0;
-  width: 50%;
   overflow: hidden;
   color: #fce205;
 }

--- a/src/main/webapp/assets/css/product-page.css
+++ b/src/main/webapp/assets/css/product-page.css
@@ -91,6 +91,24 @@
   color: #fce205;
 }
 
+.star {
+  display: inline-block;
+  position: relative;
+  font-size: 30px;
+  color: #ddd;
+}
+
+.star:after {
+  font-family: Font Awesome 5 Free;
+  content: "\f005";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 50%;
+  overflow: hidden;
+  color: #fce205;
+}
+
 mark {
   padding: 0.4rem;
   border-radius: 0.8rem;

--- a/src/main/webapp/assets/css/reviews.css
+++ b/src/main/webapp/assets/css/reviews.css
@@ -48,12 +48,12 @@
 }
 
 .name-and-date {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .rating {
-    align-self: center;
+  align-self: center;
 }
 
 /** Star rating input with hover effect */

--- a/src/main/webapp/assets/js/productpage.js
+++ b/src/main/webapp/assets/js/productpage.js
@@ -173,12 +173,19 @@ function generateRating(business){
   }
   
   var starHTML = '';
+  let rating = business.aggregatedRating;
   for (let i=0; i<5; i++) {
-    if (i+0.5<=business.aggregatedRating) {
+    if (rating >= 1.0) {
       starHTML += '<i class="fas fa-star yellow-star"></i>';
+    } else if (rating > 0) {
+      starHTML += '<i class="star fa fa-star"></i>';
+      let styleElem = document.head.appendChild(document.createElement("style")); // hacky way to overwrite the star width
+      let percentage = (rating - Math.floor(rating))*100;
+      styleElem.innerHTML = `.star:after {width: ${percentage}%;}`;
     } else {
       starHTML += '<i class="fas fa-star gray-star"></i>';
     }
+    rating -= 1;
   }
   ratingContainer.innerHTML = parseFloat(business.aggregatedRating).toFixed(2) + " " + starHTML;
 }


### PR DESCRIPTION
I made the decimal point star a very "special" star which can have its width altered in percentage values.
E.g. A rating of 3.33 will generate 3 normal yellow stars + a special 0.33-filled star + a normal gray star.